### PR TITLE
Add Jest setup and tests

### DIFF
--- a/__tests__/PasswordGenerator.test.tsx
+++ b/__tests__/PasswordGenerator.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import PasswordGenerator from '../app/password/components/PasswordGenerator'
+
+describe('PasswordGenerator', () => {
+  test('generates password with specified length when character types selected', () => {
+    render(<PasswordGenerator />)
+    fireEvent.change(screen.getByLabelText('パスワードの長さ'), { target: { value: 8 } })
+    fireEvent.click(screen.getByLabelText('大文字を含む'))
+    fireEvent.click(screen.getByText('パスワードを生成'))
+    const result = screen.getByText(/生成されたパスワード:/)
+    const password = result.textContent?.replace('生成されたパスワード: ', '') || ''
+    expect(password.length).toBe(8)
+  })
+
+  test('shows warning when no character types are selected', () => {
+    render(<PasswordGenerator />)
+    fireEvent.click(screen.getByLabelText('小文字を含む'))
+    fireEvent.click(screen.getByLabelText('数字を含む'))
+    fireEvent.click(screen.getByText('パスワードを生成'))
+    expect(screen.getByRole('alert')).toHaveTextContent('少なくとも1つの文字種を選択してください')
+  })
+})

--- a/app/password/components/PasswordGenerator.tsx
+++ b/app/password/components/PasswordGenerator.tsx
@@ -17,6 +17,7 @@ const PasswordGenerator = () => {
     const [includeNumbers, setIncludeNumbers] = useState(true)
     const [includeSymbols, setIncludeSymbols] = useState(false)
     const [generatedPassword, setGeneratedPassword] = useState('')
+    const [warningMessage, setWarningMessage] = useState('')
 
     const generatePassword = () => {
         const uppercaseChars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
@@ -29,11 +30,18 @@ const PasswordGenerator = () => {
         if (includeNumbers) characters += numberChars
         if (includeSymbols) characters += symbolChars
 
+        if (characters.length === 0) {
+            setWarningMessage('少なくとも1つの文字種を選択してください')
+            setGeneratedPassword('')
+            return
+        }
+
         let password = ''
         for (let i = 0; i < passwordLength; i++) {
             const randomIndex = Math.floor(Math.random() * characters.length)
             password += characters[randomIndex]
         }
+        setWarningMessage('')
         setGeneratedPassword(password)
     }
 
@@ -105,6 +113,11 @@ const PasswordGenerator = () => {
             >
                 パスワードを生成
             </Button>
+            {warningMessage && (
+                <Typography color="error" role="alert" sx={{ mt: 2 }}>
+                    {warningMessage}
+                </Typography>
+            )}
             {generatedPassword && (
                 <Typography
                     variant="body1"

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,13 @@
+const nextJest = require('next/jest')
+
+const createJestConfig = nextJest({
+  dir: './',
+})
+
+/** @type {import('jest').Config} */
+const customJestConfig = {
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+}
+
+module.exports = createJestConfig(customJestConfig)

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "deploy": "npm run build && aws s3 sync out s3://akirapapa-tool-site"
+    "deploy": "npm run build && aws s3 sync out s3://akirapapa-tool-site",
+    "test": "jest"
   },
   "dependencies": {
     "@emotion/react": "^11.11.4",
@@ -24,7 +25,10 @@
   "devDependencies": {
     "@types/node": "20.11.30",
     "@types/react-color": "^3.0.12",
-    "typescript": "5.4.3"
+    "typescript": "5.4.3",
+    "jest": "^29.7.0",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.4.2"
   },
   "author": "あきらパパ",
   "keywords": []


### PR DESCRIPTION
## Summary
- add Jest dev dependencies and a Jest config
- warn when no character type is selected for password
- add tests for PasswordGenerator

## Testing
- `npm test` *(fails: jest: not found)*